### PR TITLE
add codeowners for PR restriction

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.github/ @KiaanCastillo @kylesaburao
+/CNAME @KiaanCastillo
+/.gitignore @KiaanCastillo


### PR DESCRIPTION
Good practice to have one for critical files

If this is accepted, committee lead continuity will need to deal with this file