### PR TITLE
Add instagram feed using EmbedSocialWidget

### DIFF
--- a/components/EmbedSocialWidget.jsx
+++ b/components/EmbedSocialWidget.jsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+
+// Source: https://help.embedsocial.com/en/articles/4797000-how-to-embed-code-in-a-react-application
+export const EmbedSocialWidget = () => {
+  useEffect(() => {
+    (function (d, s, id) {
+      var js;
+      if (d.getElementById(id)) {
+        return;
+      }
+      js = d.createElement(s);
+      js.id = id;
+      js.src = "https://embedsocial.com/cdn/ht.js";
+      d.getElementsByTagName("head")[0].appendChild(js);
+    })(document, "script", "EmbedSocialHashtagScript");
+  }, []);
+
+  return (
+    <div
+      class="embedsocial-hashtag"
+      data-ref="d99f3c2f5873b36f57baa423a4fcba2ba39839ef"
+    >
+      <a
+        class="feed-powered-by-es feed-powered-by-es-feed-new"
+        href="https://embedsocial.com/social-media-aggregator/"
+        target="_blank"
+        title="Widget by EmbedSocial"
+      >
+        SFU SSSS Instagram Feed
+      </a>
+    </div>
+  );
+};

--- a/components/EmbedSocialWidget.jsx
+++ b/components/EmbedSocialWidget.jsx
@@ -17,11 +17,11 @@ export const EmbedSocialWidget = () => {
 
   return (
     <div
-      class="embedsocial-hashtag"
+      className="embedsocial-hashtag"
       data-ref="d99f3c2f5873b36f57baa423a4fcba2ba39839ef"
     >
       <a
-        class="feed-powered-by-es feed-powered-by-es-feed-new"
+        className="feed-powered-by-es feed-powered-by-es-feed-new"
         href="https://embedsocial.com/social-media-aggregator/"
         target="_blank"
         title="Widget by EmbedSocial"

--- a/components/index.js
+++ b/components/index.js
@@ -4,3 +4,4 @@ export { Hero } from "./Hero";
 export { HeaderNav } from "./HeaderNav";
 export { Logo } from "./Logo";
 export { Footer } from "./Footer";
+export { EmbedSocialWidget } from "./EmbedSocialWidget";

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,10 @@
-import { Helmet, Button, HeaderNav, Footer } from "@components";
+import {
+  Helmet,
+  Button,
+  HeaderNav,
+  Footer,
+  EmbedSocialWidget,
+} from "@components";
 import HappySeb from "@images/seb/happy-seb-head.svg";
 import SSSSOnDiscord from "@images/landing-page/ssss-on-discord.svg";
 import Link from "next/link.js";
@@ -70,6 +76,9 @@ export default function LandingPage() {
               <Button label="Join the SSSS Discord server" type="secondary" />
             </a>
           </div>
+        </article>
+        <article>
+          <EmbedSocialWidget />
         </article>
       </main>
       <Footer />


### PR DESCRIPTION
Add an Instagram feed to the main page to increase website traffic and redirect more people to Instagram.
Utilized [EmbedSocial](https://embedsocial.com/) third-party library since embedding Instagram manually is a bit complicated. Since this uses a free plan, the layout, and style cannot be customized.

The design uses a carousel that also slides automatically. I think having 3 big posts are a good option since we want to emphasize the latest post, this comes with a slider and the user can still view the other posts. 

Other free alternative:
- https://behold.so/


Screenshot 1:
<img width="1440" alt="image" src="https://github.com/ssss-sfu/ssss-sfu.github.io/assets/70176191/30e7992e-3532-4c2c-ab76-fa52350b8a31">

Screenshot 2 - Hover:
<img width="1437" alt="image" src="https://github.com/ssss-sfu/ssss-sfu.github.io/assets/70176191/fd5b9eb6-c8f4-4043-8d7c-f9a9fd6a8752">

