### PR TITLE
Blog routes export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,12 @@ const nextConfig = {
   swcMinify: true,
   output: "export",
   images: {
-    domains: ["cdn.sanity.io"],
+    remotePatterns: [
+      {
+        hostname: "cdn.sanity.io",
+      },
+    ],
+    unoptimized: true,
   },
   webpack: (config, { isServer }) => {
     if (!isServer) {

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -5,14 +5,13 @@ import { useLiveQuery } from "next-sanity/preview";
 import { readToken } from "../api/sanity.api";
 import { getClient } from "../api/sanity.client";
 import { urlForImage } from "../api/sanity.image";
-import { Helmet, HeaderNav, Footer } from "@components";
+import { Helmet } from "@components";
 import {
   getPost,
   postBySlugQuery,
   postSlugsQuery,
 } from "../api/sanity.queries";
 import React from "react";
-import { useRouter } from "next/router";
 import clock from "../../public/images/blog-page/clock.svg";
 import person from "../../public/images/blog-page/person.svg";
 import { formatDate } from "utils/index";
@@ -37,15 +36,13 @@ export const getStaticProps = async ({ draftMode = false, params = {} }) => {
 };
 
 export default function ProjectSlugRoute(props) {
-  const router = useRouter();
   const [post] = useLiveQuery(props.post, postBySlugQuery, {
     slug: props.post.slug.current,
   });
 
   return (
     <div className="blog-category-page">
-      <Helmet pageTitle={router.pathname} />
-      <HeaderNav />
+      <Helmet pageTitle={post.title} />
       <main>
         <header className="container hero">
           {post.mainImage ? (
@@ -78,7 +75,6 @@ export default function ProjectSlugRoute(props) {
           <PortableText value={post.body} />
         </div>
       </main>
-      <Footer />
     </div>
   );
 }
@@ -86,8 +82,9 @@ export default function ProjectSlugRoute(props) {
 export const getStaticPaths = async () => {
   const client = getClient();
   const slugs = await client.fetch(postSlugsQuery);
+  const paths = slugs.map((slug) => ({ params: { slug } }));
   return {
-    paths: slugs ? slugs.map(({ slug }) => `/blog/${slug}`) : [],
+    paths,
     fallback: false,
   };
 };

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,9 +1,9 @@
 import { useLiveQuery } from "next-sanity/preview";
 
 import Card from "components/Card";
-import { readToken } from "./api/sanity.api";
-import { getClient } from "./api/sanity.client";
-import { getPosts, postsQuery } from "./api/sanity.queries";
+import { readToken } from "../api/sanity.api";
+import { getClient } from "../api/sanity.client";
+import { getPosts, postsQuery } from "../api/sanity.queries";
 import { Helmet, HeaderNav, Footer } from "@components";
 import { useRouter } from "next/router";
 
@@ -23,10 +23,10 @@ export const getStaticProps = async ({ draftMode = false }) => {
 export default function Post(props) {
   const router = useRouter();
   const [posts] = useLiveQuery(props.posts, postsQuery);
+
   return (
     <div className="blog-page">
       <Helmet pageTitle={router.pathname} />
-      <HeaderNav />
       <main>
         <header className="container hero">
           <p>Blog</p>
@@ -47,7 +47,6 @@ export default function Post(props) {
           )}
         </section>
       </main>
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
Main fix: Blog routes cannot be exported


Other changes:
- Update `next.config.js`
- Move `blog.js` to `blog/index.js` for better organization
- Remove header nav and footer (it's already in the global layout)