### PR TITLE
Make a script to fetch general data of all sosy courses to json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/course-explorer-script"]
+	path = scripts/course-explorer-script
+	url = git@github.com:ssss-sfu/course-explorer-script.git

--- a/public/jsons/courses.json
+++ b/public/jsons/courses.json
@@ -1,0 +1,7409 @@
+[
+    {
+        "requirement": "Lower Divison Core",
+        "courses": [
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "105W",
+                    "title": "Social Issues and Communication Strategies in Computing Science",
+                    "description": "This course teaches the fundamentals of informative and persuasive communication for professional engineers and computer scientists. A principal goal of this course is to assist students in thinking critically about various contemporary technical, social, and ethical issues. It focuses on communicating technical information clearly and concisely, managing issues of persuasion when communicating with diverse audiences, presentation skills, and teamwork.",
+                    "prerequisites": "",
+                    "corequisites": "",
+                    "notes": "Students with credit for ENSC 102, ENSC 105W, MSE 101W or SEE 101W may not take CMPT 105W for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6880",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Tara Immell"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "18:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "19:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "6042",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Tara Immell"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "18:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E200",
+                                "classNumber": "6043",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Herbert Tsang"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "18:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "130",
+                    "title": "Introduction to Computer Programming I",
+                    "description": "An introduction to computing science and computer programming, using a systems oriented language, such as C or C++. This course introduces basic computing science concepts. Topics will include: elementary data types, control structures, functions, arrays and strings, fundamental algorithms, computer organization and memory management.",
+                    "prerequisites": "BC Math 12 (or equivalent, or any of MATH 100, 150, 151, 154, or 157, with a minimum grade of C-).",
+                    "corequisites": "",
+                    "notes": "Students with credit for CMPT 102, 120, 128 or 166 may not take this course for further credit. Students who have taken CMPT 125, 129 or 135 first may not then take this course for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6099",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6100",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6102",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6103",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6104",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6105",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6108",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6109",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6110",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "term": "Spring 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6669",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6674",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6675",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6676",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6677",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6678",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6679",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6680",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6681",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6906",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6919",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6920",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6921",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6922",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6923",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6924",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6925",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6926",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Spring 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6669",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6674",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6675",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6676",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6677",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6678",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6679",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6680",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6681",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "210",
+                    "title": "Probability and Computing",
+                    "description": "Probability has become an essential tool in modern computer science with applications in randomized algorithms, computer vision and graphics, systems, data analysis, and machine learning. The course introduces the foundational concepts in probability as required by many modern applications in computing.",
+                    "prerequisites": "MACM 101, MATH 152, CMPT 125 or CMPT 135, and (MATH 240 or MATH 232), all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6998",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Sharan Vaswani"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6126",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "213",
+                    "title": "Object Oriented Design in Java",
+                    "description": "An introduction to object oriented design using Java. The Java programming language is introduced,\r\nwith an emphasis on its advanced features. The course covers the building blocks of object oriented\r\ndesign including inheritance, polymorphism, interfaces and abstract classes. A number of object oriented design patterns are presented, such as observer, iterator, and singleton. The course also teaches best-practices in code construction. It includes a basic introduction to programming event driven graphical user interfaces.",
+                    "prerequisites": "CMPT 225 with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "Students with credit for CMPT 212 cannot take this course for further credit. ",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6999",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6132",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Bobby Chan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "225",
+                    "title": "Data Structures and Programming",
+                    "description": "Introduction to a variety of practical and important data structures and methods for implementation and for experimental and analytical evaluation. Topics include: stacks, queues and lists; search trees; hash tables and algorithms; efficient sorting; object-oriented programming; time and space efficiency analysis; and experimental evaluation. ",
+                    "prerequisites": "(MACM 101 and (CMPT 125, CMPT 129 or CMPT 135)) or (ENSC 251 and ENSC 252), all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7003",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "David Mitchell"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "7004",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "7005",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D203",
+                                "classNumber": "7006",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D204",
+                                "classNumber": "7007",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "7008",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D206",
+                                "classNumber": "7009",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D207",
+                                "classNumber": "7010",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D208",
+                                "classNumber": "7011",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "7002",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "18:30"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E101",
+                                "classNumber": "7012",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E102",
+                                "classNumber": "7013",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E103",
+                                "classNumber": "7014",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E104",
+                                "classNumber": "7015",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E105",
+                                "classNumber": "7016",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E106",
+                                "classNumber": "7017",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E107",
+                                "classNumber": "7018",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E108",
+                                "classNumber": "7019",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6171",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6172",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6173",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6174",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6175",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6176",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6177",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6178",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6179",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6186",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "6187",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "6188",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D203",
+                                "classNumber": "6189",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D204",
+                                "classNumber": "6190",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "6191",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D206",
+                                "classNumber": "6192",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D207",
+                                "classNumber": "6193",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D208",
+                                "classNumber": "6194",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Toby Donaldson"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "276",
+                    "title": "Introduction to Software Engineering",
+                    "description": "An overview of various techniques used for software development and software project management. Major tasks and phases in modern software development, including requirements, analysis, documentation, design, implementation, testing,and maintenance. Project management issues are also introduced. Students complete a team project using an iterative development process.",
+                    "prerequisites": "One W course, CMPT 225, (MACM 101 or (ENSC 251 and ENSC 252)) and (MATH 151 or MATH 150), all with a minimum grade of C-. MATH 154 or MATH 157 with at least a B+ may be substituted for MATH 151 or MATH 150.",
+                    "corequisites": "",
+                    "notes": "Students with credit for CMPT 275 may not take this course for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7020",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Saba Alimadadi Jani"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7021",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Bobby Chan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6207",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Saba Alimadadi Jani"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6208",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Steve Pearce"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "6209",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Parsa Rajabi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "295",
+                    "title": "Introduction to Computer Systems",
+                    "description": "The curriculum introduces students to topics in computer architecture that are considered fundamental to an understanding of the digital systems underpinnings of computer systems. ",
+                    "prerequisites": "Either (MACM 101 and (CMPT 125 or CMPT 135)) or (MATH 151 and CMPT 102 for students in an Applied Physics program), all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6979",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anne Lavergne"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6981",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6982",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6983",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6984",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6985",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6986",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6987",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6988",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6980",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "6989",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "6990",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D203",
+                                "classNumber": "6991",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D204",
+                                "classNumber": "6992",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "6993",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D206",
+                                "classNumber": "6994",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D207",
+                                "classNumber": "6995",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D208",
+                                "classNumber": "6996",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6210",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6211",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6212",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6213",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6214",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6215",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6216",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6217",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6218",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D109",
+                                "classNumber": "6219",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen",
+                                    "Arrvindh Shriraman"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "MACM",
+                    "number": "101",
+                    "title": "Discrete Mathematics I",
+                    "description": "Introduction to graph theory, trees, induction, automata theory, formal reasoning, modular arithmetic.",
+                    "prerequisites": "BC Math 12 (or equivalent), or any of MATH 100, 150, 151, 154, 157.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6907",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6942",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6943",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6944",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6945",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6946",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6947",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6948",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6949",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6908",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "6950",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "6951",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D203",
+                                "classNumber": "6952",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D204",
+                                "classNumber": "6953",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "6954",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D206",
+                                "classNumber": "6955",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D207",
+                                "classNumber": "6956",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D208",
+                                "classNumber": "6957",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6232",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6233",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "6234",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "6235",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "6240",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "6241",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D106",
+                                "classNumber": "6242",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D107",
+                                "classNumber": "6243",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D108",
+                                "classNumber": "6244",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6245",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "6246",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "6247",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D203",
+                                "classNumber": "6277",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D204",
+                                "classNumber": "6278",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "6279",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D206",
+                                "classNumber": "6280",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D207",
+                                "classNumber": "6284",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "17:30",
+                                    "endTime": "18:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D208",
+                                "classNumber": "6285",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Andrei Bulatov"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "17:30",
+                                    "endTime": "18:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "6419",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D301",
+                                "classNumber": "6420",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D302",
+                                "classNumber": "6421",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D303",
+                                "classNumber": "6422",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D304",
+                                "classNumber": "6423",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D305",
+                                "classNumber": "6424",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D306",
+                                "classNumber": "6425",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D307",
+                                "classNumber": "6426",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D308",
+                                "classNumber": "6427",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "MSE",
+                    "number": "110",
+                    "title": "Mechatronics Design I",
+                    "description": "First year project course designed to provide students with a first exposure to the challenges of project organization. Students are responsible for designing and constructing a mechanical robot optimized to solve a particular chosen task. The engineering challenges of the project are expected to focus half on mechanical design and half on control algorithm design and implementation.",
+                    "prerequisites": "",
+                    "corequisites": "",
+                    "notes": "Students with credit for ENSC 182 may not take MSE 110 for further credit.",
+                    "deliveryMethod": "None",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "2256",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Amr Marzouk"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "LAB1",
+                                "classNumber": "2272",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Amr Marzouk"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "LAB2",
+                                "classNumber": "7592",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Amr Marzouk"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LAB",
+                                    "startTime": "8:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "STAT",
+                    "number": "271",
+                    "title": "Probability and Statistics for Computing Science",
+                    "description": "This is an introductory course in probability and statistics that is designed for Computer Science students. Mainly covers basic probability theory and statistical methods for designing and analyzing computing algorithms and systems. Topics include continuous probability distributions, random variables, multivariate normal distributions, parameter estimation and inference theory, as well as design and analysis of statistical studies, including hypothesis testing and presentation of statistical data.",
+                    "prerequisites": "CMPT 210 with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "4018",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Gary Parker"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "4020",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Gary Parker"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "TUT",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6410",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Gary Parker"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "6411",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Gary Parker"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "TUT",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "MATH",
+                    "number": "150",
+                    "title": "Calculus I with Review",
+                    "description": "Designed for students specializing in mathematics, physics, chemistry, computing science and engineering. Topics as for Math 151 with a more extensive review of functions, their properties and their graphs. Recommended for students with no previous knowledge of Calculus. In addition to regularly scheduled lectures, students enrolled in this course are encouraged to come for assistance to the Calculus Workshop (Burnaby), or Math Open Lab (Surrey). ",
+                    "prerequisites": "Pre-Calculus 12 (or equivalent) with a grade of at least B+, or MATH 100 with a grade of at least B-, or achieving a satisfactory grade on the Simon Fraser University Calculus Readiness Test.",
+                    "corequisites": "",
+                    "notes": "Students with credit for either MATH 151, 154 or 157 may not take MATH 150 for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "4"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7754",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "MacKenzie Carr"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "7755",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "7756",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "7759",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D206",
+                                "classNumber": "7760",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D207",
+                                "classNumber": "7764",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D208",
+                                "classNumber": "7765",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "3836",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D401",
+                                "classNumber": "6233",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D402",
+                                "classNumber": "4007",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D403",
+                                "classNumber": "4008",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "3823",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP02",
+                                "classNumber": "3833",
+                                "type": "n",
+                                "campus": "",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": []
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "2030",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Sophie Burrill"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D101",
+                                "classNumber": "2072",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D102",
+                                "classNumber": "2073",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D103",
+                                "classNumber": "2074",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D104",
+                                "classNumber": "2075",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D105",
+                                "classNumber": "2076",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "2156",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Jamie Mulholland"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D201",
+                                "classNumber": "5667",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D202",
+                                "classNumber": "5672",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D203",
+                                "classNumber": "5668",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D204",
+                                "classNumber": "5669",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D205",
+                                "classNumber": "5670",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "7883",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Mahsa Faizrahnemoon"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D301",
+                                "classNumber": "7887",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D302",
+                                "classNumber": "7888",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D303",
+                                "classNumber": "7889",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "2144",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D401",
+                                "classNumber": "2194",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D402",
+                                "classNumber": "2195",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D403",
+                                "classNumber": "2196",
+                                "type": "n",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "SEM",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "2031",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP02",
+                                "classNumber": "2145",
+                                "type": "n",
+                                "campus": "",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": []
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "MATH",
+                    "number": "151",
+                    "title": "Calculus I",
+                    "description": "Designed for students specializing in mathematics, physics, chemistry, computing science and engineering. Logarithmic and exponential functions, trigonometric functions, inverse functions. Limits, continuity, and derivatives. Techniques of differentiation, including logarithmic and implicit differentiation. The Mean Value Theorem. Applications of differentiation including extrema, curve sketching, Newton's method. Introduction to modeling with differential equations. Polar coordinates, parametric curves. ",
+                    "prerequisites": "Pre-Calculus 12 (or equivalent) with a grade of at least A, or MATH 100 with a grade of at least B, or achieving a satisfactory grade on the Simon Fraser University Calculus Readiness Test.",
+                    "corequisites": "",
+                    "notes": "Students with credit for either MATH 150, 154 or 157 may not take MATH 151 for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "2029",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Sophie Burrill"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "4146",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Jamie Mulholland"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "7884",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Mahsa Faizrahnemoon"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "2036",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Natalia Kouzniak"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "2150",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP02",
+                                "classNumber": "2151",
+                                "type": "n",
+                                "campus": "",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": []
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "MATH",
+                    "number": "152",
+                    "title": "Calculus II",
+                    "description": "Riemann sum, Fundamental Theorem of Calculus, definite, indefinite and improper integrals, approximate integration, integration techniques, applications of integration. First-order separable differential equations and growth models. Sequences and series, series tests, power series, convergence and applications of power series.",
+                    "prerequisites": "MATH 150 or 151, with a minimum grade of C-; or MATH 154 or 157 with a grade of at least B.",
+                    "corequisites": "",
+                    "notes": "Students with credit for MATH 155 or 158 may not take this course for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "3832",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Michael Monagan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "3831",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Jamie Mulholland"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "4289",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "3855",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Vijaykumar Singh"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "3830",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP02",
+                                "classNumber": "3829",
+                                "type": "n",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "2020",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Nathan Ilten"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "2021",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "MATH",
+                    "number": "232",
+                    "title": "Applied Linear Algebra",
+                    "description": "Linear equations, matrices, determinants. Introduction to vector spaces and linear transformations and bases. Complex numbers. Eigenvalues and eigenvectors; diagonalization. Inner products and orthogonality; least squares problems. An emphasis on applications involving matrix and vector calculations.",
+                    "prerequisites": "MATH 150 or 151 or MACM 101, with a minimum grade of C-; or MATH 154 or 157, both with a grade of at least B.",
+                    "corequisites": "",
+                    "notes": "Students with credit for MATH 240 may not take this course for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "3812",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Fatemeh Panjeh Ali Beik"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7461",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "3827",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Justin Chan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "3813",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP02",
+                                "classNumber": "3828",
+                                "type": "n",
+                                "campus": "",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": []
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "2041",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brenda Davison"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "2053",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Abraham Punnen",
+                                    "Jas Dhahan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP01",
+                                "classNumber": "2042",
+                                "type": "n",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "OPL",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "OP02",
+                                "classNumber": "2055",
+                                "type": "n",
+                                "campus": "",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": []
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "requirement": "Upper Divison Core",
+        "courses": [
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "307",
+                    "title": "Data Structures and Algorithms",
+                    "description": "Design and analysis of efficient data structures and algorithms. General techniques for building and analyzing algorithms (greedy, divide & conquer, dynamic programming, network flows). Introduction to NP-completeness.",
+                    "prerequisites": "CMPT 225, (MACM 201 or CMPT 210), (MATH 150 or MATH 151), and (MATH 232 or MATH 240), all with a minimum grade of C-. MATH 154 or MATH 157 with a grade of at least B+ may be substituted for MATH 150 or MATH 151.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7028",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Qianping Gu"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7030",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "19:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "18:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "7031",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Kay C Wiese"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6061",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Brad Bart"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "7926",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Kay C Wiese"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "18:50"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "18:50"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:30",
+                                    "endTime": "18:50"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "376W",
+                    "title": "Professional Responsibility and Technical Writing",
+                    "description": "Covers professional writing in computing science, including format conventions and technical reports. The basis for ethical decision-making and the methodology for reaching ethical decisions concerning computing matters will be studied. Students will survey and write research papers, and both individual and group work will be emphasized.",
+                    "prerequisites": "CMPT 105W and (CMPT 275 or CMPT 276), with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7045",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Steve Pearce"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7046",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Sessional"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6145",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Angelica Lim"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "requirement": "Systems Requirements",
+        "courses": [
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "300",
+                    "title": "Operating Systems I",
+                    "description": "This course aims to give the student an understanding of what a modern operating system is, and the services it provides. It also discusses some basic issues in operating systems and provides solutions. Topics include multiprogramming, process management, memory management, and file systems.",
+                    "prerequisites": "CMPT 225 and (CMPT 295 or ENSC 254), all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7029",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Harinder Khangura"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "7795",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Harinder Khangura"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "19:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6060",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Harinder Khangura"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "7881",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Harinder Khangura"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "19:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "19:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "354",
+                    "title": "Database Systems I",
+                    "description": "Logical representations of data records. Data models. Studies of some popular file and database systems. Document retrieval. Other related issues such as database administration, data dictionary and security.",
+                    "prerequisites": "CMPT 225 and (MACM 101 or (ENSC 251 and ENSC 252)), all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "7038",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Evgenia Ternovska"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6140",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Martin Ester"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "6150",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Ke Wang"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D400",
+                                "classNumber": "7764",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "John Edgar"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "371",
+                    "title": "Data Communications and Networking",
+                    "description": "Data communication fundamentals (data types, rates, and transmission media). Network architectures for local and wide areas. Communications protocols suitable for various architectures. ISO protocols and internetworking. Performance analysis under various loadings and channel error rates.",
+                    "prerequisites": "CMPT 225 and (MATH 151 or MATH 150), with a minimum grade of C-. MATH 154 or MATH 157 with a grade of at least B+ may be substituted for MATH 151 (MATH 150).",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7043",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Balbir Gill"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "17:00",
+                                    "endTime": "19:50"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6144",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Ouldooz Baghban Karimi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "term": "Summer 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "4071",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Bobby Chan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7044",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Bobby Chan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "9:30",
+                                    "endTime": "10:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Summer 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "4071",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Bobby Chan"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "431",
+                    "title": "Distributed Systems",
+                    "description": "An introduction to distributed systems: systems consisting of multiple physical components connected over a network. Architectures of such systems, ranging from client-server to peer-to-peer. Distributed systems are analyzed via case studies of real network file systems, replicated systems, sensor networks and peer-to-peer systems. Hands-on experience designing and implementing a complex distributed system.",
+                    "prerequisites": "CMPT 300, 371, both with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "Students with credit for CMPT 401 before September 2008 may not take this course for further credit.",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7117",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Alaa Alameldeen"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6158",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Keval Vora"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "9:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "10:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "term": "Spring 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6763",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7118",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Spring 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6763",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Brian Fraser"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "454",
+                    "title": "Database Systems II",
+                    "description": "An advanced course on database systems which covers crash recovery, concurrency control, transaction processing, distributed database systems as the core material and a set of selected topics based on the new developments and research interests, such as object-oriented data models and systems, extended relational systems, deductive database systems, and security and integrity.",
+                    "prerequisites": "CMPT 300 and 354, with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "E100",
+                                "classNumber": "7116",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Ke Wang"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "18:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "16:30",
+                                    "endTime": "17:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "7765",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "John Edgar"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday",
+                                        "Wednesday",
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "13:30",
+                                    "endTime": "14:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "term": "Fall 2022",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "5358",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Khaled Diab",
+                                    "Mohamed Hefeeda"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7129",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "15:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2022",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "5358",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Khaled Diab",
+                                    "Mohamed Hefeeda"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "requirement": "Software Engineering Requirements",
+        "courses": [
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "373",
+                    "title": "Software Development Methods",
+                    "description": "Survey of modern software development methodology. Several software development process models will be examined, as will the general principles behind such models. Provides experience with different programming paradigms and their advantages and disadvantages during software development.",
+                    "prerequisites": "CMPT 276 or 275, with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6152",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "William Sumner"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "473",
+                    "title": "Software Testing, Reliability and Security",
+                    "description": "Methods for software quality assurance focusing on reliability and security. Test coverage and test data adequacy including combinatorial testing. MC/DC testing, and mutation testing. Security engineering techniques for vulnerability discovery and mitigation including fuzz testing. Testing techniques will be applied to the assessment of external open source software.",
+                    "prerequisites": "(CMPT 275 or CMPT 276) with a minimum grade of C- and 15 upper division CMPT units.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6166",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "William Sumner"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "379",
+                    "title": "Principles of Compiler Design",
+                    "description": "This course covers the key components of a compiler for a high level programming language. Topics include lexical analysis, parsing, type checking, code generation and optimization. Students will work in teams to design and implement an actual compiler making use of tools such as lex and yacc. ",
+                    "prerequisites": "(MACM 201 or CMPT 210), (CMPT 295 or ENSC 215) and CMPT 225, all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6153",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Thomas Shermer"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "383",
+                    "title": "Comparative Programming Languages",
+                    "description": "Various concepts and principles underlying the design and use of modern programming languages are considered in the context of procedural, object-oriented, functional and logic programming languages. Topics include data and control structuring constructs, facilities for modularity and data abstraction, polymorphism, syntax, and formal semantics.",
+                    "prerequisites": "CMPT 225 and (MACM 101 or (ENSC 251 and ENSC 252)), all with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7047",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Yuepeng Wang"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6146",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Anders Miltner"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "8:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "term": "Spring 2019",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6700",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Rob Cameron"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Spring 2019",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6700",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Rob Cameron"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "13:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "11:30",
+                                    "endTime": "12:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "term": "Spring 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6766",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Ouldooz Baghban Karimi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7135",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Ouldooz Baghban Karimi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "12:20"
+                                },
+                                {
+                                    "days": [
+                                        "Wednesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "10:30",
+                                    "endTime": "11:20"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Spring 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6766",
+                                "type": "e",
+                                "campus": "Surrey",
+                                "instructorNames": [
+                                    "Ouldooz Baghban Karimi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Monday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "15:20"
+                                },
+                                {
+                                    "days": [
+                                        "Thursday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "14:30",
+                                    "endTime": "16:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "477",
+                    "title": "Introduction to Formal Verification",
+                    "description": "Introduces, at an accessible level, a formal framework for symbolic model checking, one of the most important verification methods. The techniques are illustrated with examples of verification of reactive systems and communication protocols. Students learn to work with a model checking tool.",
+                    "prerequisites": "CMPT 275 or 276, with a minimum grade of C-.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": []
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "6851",
+                                "type": "e",
+                                "campus": "Burnaby",
+                                "instructorNames": [
+                                    "Yuepeng Wang"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Tuesday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "14:20"
+                                },
+                                {
+                                    "days": [
+                                        "Friday"
+                                    ],
+                                    "sectionCode": "LEC",
+                                    "startTime": "12:30",
+                                    "endTime": "13:20"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "requirement": "Capstone Project Requirements",
+        "courses": [
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "494",
+                    "title": "Software Systems Program Capstone Project I",
+                    "description": "This course is the first in a series of two 3 unit courses for the Software Systems Capstone Project. Students will work in teams on a closely supervised software systems project. Projects can be research based or have a significant software application, potentially based on a real customer application specification, as their basis. Students will be required to write a full project report and present their project during the Capstone Project Day Presentations.",
+                    "prerequisites": "Students must have completed at least 15 units of upper division CMPT courses. Successful Capstone Project Proposal.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7130",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7131",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "7132",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "5180",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": [
+                                    "Keval Vora",
+                                    "William Sumner"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "5182",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": [
+                                    "Ouldooz Baghban Karimi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "5183",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "info": {
+                    "dept": "CMPT",
+                    "number": "495",
+                    "title": "Software Systems Capstone Project II",
+                    "description": "This course is the second in a series of two 3 unit courses for the Software Systems Capstone Project. Students will work in teams or a closely supervised software systems project. Projects can be research based or have a significant software application, potentially based on a real customer specification. Students will be required to write a final project report at the end of the term and do a project presentation during the Capstone Presentation Day.",
+                    "prerequisites": "CMPT 494 with a minimum grade of C-. CMPT 495 must be taken in the term immediately following the successful completion of CMPT 494 and must be for the same project and faculty supervisor.",
+                    "corequisites": "",
+                    "notes": "",
+                    "deliveryMethod": "In Person",
+                    "units": "3"
+                },
+                "future_sections": {
+                    "term": "Spring 2024",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "7133",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": [
+                                    "Ouldooz Baghban Karimi"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "7134",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": [
+                                    "Keval Vora",
+                                    "William Sumner"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "7136",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "last_sections": {
+                    "term": "Fall 2023",
+                    "sections": [
+                        {
+                            "info": {
+                                "section": "D100",
+                                "classNumber": "5181",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": [
+                                    "Tianzheng Wang"
+                                ]
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D200",
+                                "classNumber": "5184",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        },
+                        {
+                            "info": {
+                                "section": "D300",
+                                "classNumber": "5185",
+                                "type": "e",
+                                "campus": "None",
+                                "instructorNames": []
+                            },
+                            "courseSchedule": [
+                                {
+                                    "days": [],
+                                    "sectionCode": "CAP",
+                                    "startTime": "None",
+                                    "endTime": "None"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
**Background**:
As part of the course explorer feature, we want to have courses availability on the site. The data is available through SFU Course Outline API, but fetching it every time is expensive especially since the data only changes a few times or ideally once per term. Thus, we should just use a script to pull it and the site should just get it from local json data.

**Changes**:
- Made a script in https://github.com/ssss-sfu/course-explorer-script
- Add the git submodule linked to that repo
- Generated `courses.json` file inside `public/jsons`