### PR TITLE
Updated Google Calendar Integration to be Dynamic and Enhanced CSS

### DIFF
--- a/components/EventsCalendar.tsx
+++ b/components/EventsCalendar.tsx
@@ -4,6 +4,9 @@ import format from "date-fns/format";
 import getDay from "date-fns/getDay";
 import parse from "date-fns/parse";
 import startOfWeek from "date-fns/startOfWeek";
+import addMonths from "date-fns/addMonths";
+import subMonths from "date-fns/subMonths";
+import isToday from "date-fns/isToday";
 
 const locales = {
   "en-US": require("date-fns/locale/en-US"),
@@ -18,25 +21,54 @@ const localizer = dateFnsLocalizer({
 });
 
 export const EventsCalendar: React.FC = () => {
-  const calendarURL: string =
-    "https://clients6.google.com/calendar/v3/calendars/j7qfcngd9crbhelib6tgdihi3k@group.calendar.google.com/events?calendarId=j7qfcngd9crbhelib6tgdihi3k%40group.calendar.google.com&singleEvents=true&timeZone=America%2FVancouver&maxAttendees=1&maxResults=250&sanitizeHtml=true&timeMin=2023-03-26T00%3A00%3A00-07%3A00&timeMax=2024-05-07T00%3A00%3A00-07%3A00&key=AIzaSyBNlYH01_9Hc5S1J9vuFmu2nUqBZJNAXxs";
+  const googleCalendarID =
+    "j7qfcngd9crbhelib6tgdihi3k%40group.calendar.google.com";
+  const apiKey = "AIzaSyBNlYH01_9Hc5S1J9vuFmu2nUqBZJNAXxs";
   const [events, setEvents] = useState<any[]>([]);
 
   useEffect(() => {
+    // Will fetch events from Google Calendar API
+    // Within a time range of 3 months in the past to 6 months in the future
+    const now = new Date();
+    const timeMin = subMonths(now, 3).toISOString();
+    const timeMax = addMonths(now, 6).toISOString();
+
+    const calendarURL = `https://www.googleapis.com/calendar/v3/calendars/${googleCalendarID}/events?key=${apiKey}&timeMin=${timeMin}&timeMax=${timeMax}&singleEvents=true&orderBy=startTime`;
+
     fetch(calendarURL)
       .then((response) => response.json())
       .then((data) => {
         const updatedEvents: any[] = [];
-        for (const event of data.items) {
-          updatedEvents.push({
-            title: event.summary,
-            start: new Date(event.start.dateTime),
-            end: new Date(event.end.dateTime),
-          });
+        if (data.items) {
+          for (const event of data.items) {
+            // Handles both all-day and timed events
+            const start = event.start?.dateTime || event.start?.date;
+            const end = event.end?.dateTime || event.end?.date;
+            if (start && end) {
+              updatedEvents.push({
+                title: event.summary,
+                start: new Date(start),
+                end: new Date(end),
+              });
+            }
+          }
         }
         setEvents(updatedEvents);
+      })
+      // catch block to display errors
+      .catch((error) => {
+        console.error("Error fetching calendar events:", error);
       });
   }, []);
+
+  const dayPropGetter = (date: Date) => {
+    if (isToday(date)) {
+      return {
+        className: "today",
+      };
+    }
+    return {};
+  };
 
   return (
     <div className="eventsCalendar">
@@ -49,6 +81,7 @@ export const EventsCalendar: React.FC = () => {
         startAccessor="start"
         endAccessor="end"
         style={{ height: 750 }}
+        dayPropGetter={dayPropGetter}
       />
     </div>
   );

--- a/styles/components/events-calendar/events-calendar.scss
+++ b/styles/components/events-calendar/events-calendar.scss
@@ -118,7 +118,32 @@
     scrollbar-width: none; /* Firefox */
   }
 }
+// Highlight today's date cell
+.today-cell {
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 10px;
+    height: 10px;
+    background-color: #ffdf00;
+    border-radius: 50%;
+    z-index: 1;
+  }
+}
 
 .rbc-today {
-  background-color: inherit;
+  .rbc-date-cell {
+    color: #ffdf00;
+    font-weight: bold;
+  }
+  background-color: rgba(
+    36,
+    169,
+    139,
+    0.25
+  ); // light green with some transparency;
 }


### PR DESCRIPTION
Integration was broken in the past because the date range was limited to some date back in 2024. Updated it to be dynamic, so the website will now show events from the past 3 months to the next 6 months.

Calendar now also handles date/time + all-day events.

Also added some css to indicate/highlight the current day's cell

Before:
<img width="1372" height="748" alt="image" src="https://github.com/user-attachments/assets/d2bdd787-295e-45d0-b963-edcadda743a7" />

After:
<img width="1344" height="703" alt="image" src="https://github.com/user-attachments/assets/20ae1990-8290-4b60-93ac-8a82fadb1be9" />
